### PR TITLE
Migrate Invoke-vnc to python3

### DIFF
--- a/gen_buffer.py
+++ b/gen_buffer.py
@@ -12,5 +12,5 @@ res = res.rstrip()
 res = res.rstrip(',')
 res = "unsigned int vncbuffer_len = "  + str(len(dll)) + ";\nunsigned char vncbuffer[] = \n{" + res + "};"
 
-print res
+print(res)
 

--- a/vncexec.py
+++ b/vncexec.py
@@ -232,7 +232,7 @@ class VNCEXEC:
             pass
         elif contype == 'reverse':
             if bc_ip is None:
-                print 'Ip addr required for reverse connection'
+                print('Ip addr required for reverse connection')
                 sys.exit(1)
             else:
                 self.launch_string += '-IpAddress ' + bc_ip 
@@ -361,17 +361,17 @@ class RemoteShell(cmd.Cmd):
         os.system(s)
 
     def do_help(self, line):
-        print """
+        print("""
  lcd {path}                 - changes the current local directory to {path}
  exit                       - terminates the server process (and this session)
  put {src_file, dst_path}   - uploads a local file to the dst_path (dst_path = default current directory)
  get {file}                 - downloads pathname to the current local dir 
  ! {cmd}                    - executes a local shell cmd
-""" 
+""") 
 
     def do_lcd(self, s):
         if s == '':
-            print os.getcwd()
+            print(os.getcwd())
         else:
             try:
                 os.chdir(s)
@@ -425,7 +425,7 @@ class RemoteShell(cmd.Cmd):
     def do_cd(self, s):
         self.execute_remote('cd ' + s)
         if len(self.__outputBuffer.strip('\r\n')) > 0:
-            print self.__outputBuffer
+            print(self.__outputBuffer)
             self.__outputBuffer = ''
         else:
             self.__pwd = ntpath.normpath(ntpath.join(self.__pwd, s))
@@ -441,7 +441,7 @@ class RemoteShell(cmd.Cmd):
             self.execute_remote(line)
             if len(self.__outputBuffer.strip('\r\n')) > 0: 
                 # Something went wrong
-                print self.__outputBuffer
+                print(self.__outputBuffer)
                 self.__outputBuffer = ''
             else:
                 # Drive valid, now we should get the current path

--- a/vncexec.py
+++ b/vncexec.py
@@ -17,7 +17,7 @@ import base64
 import os.path
 import os
 import sys
-import StringIO
+from io import StringIO
 import time
 import logging
 import argparse
@@ -25,8 +25,8 @@ import cmd
 import ntpath
 import uuid
 import string
-import SimpleHTTPServer
-import SocketServer
+import http.server
+import socketserver
 import threading
 import tempfile
 
@@ -285,7 +285,7 @@ class VNCEXEC:
                 time.sleep(10)
                 self.smbConnection.deleteFile(self.__share, self.full_file_path)
                 logging.info("File " + self.__share + self.full_file_path + " deleted")
-            except  (Exception, KeyboardInterrupt), e:
+            except  (Exception, KeyboardInterrupt) as e:
                 #import traceback
                 #traceback.print_exc()
                 logging.error(str(e))
@@ -326,7 +326,7 @@ class VNCEXEC:
                 while True:
                     pass
                 dcom.disconnect()
-            except (Exception, KeyboardInterrupt), e:
+            except (Exception, KeyboardInterrupt) as e:
                 #import traceback
                 #traceback.print_exc()
                 logging.error(str(e))
@@ -375,7 +375,7 @@ class RemoteShell(cmd.Cmd):
         else:
             try:
                 os.chdir(s)
-            except Exception, e:
+            except Exception as e:
                 logging.error(str(e))
 
     def do_get(self, src_path):
@@ -388,7 +388,7 @@ class RemoteShell(cmd.Cmd):
             logging.info("Downloading %s\\%s" % (drive, tail))
             self.__transferClient.getFile(drive[:-1]+'$', tail, fh.write)
             fh.close()
-        except Exception, e:
+        except Exception as e:
             logging.error(str(e))
             os.remove(filename)
             pass
@@ -412,7 +412,7 @@ class RemoteShell(cmd.Cmd):
             logging.info("Uploading %s to %s" % (src_file, pathname))
             self.__transferClient.putFile(drive[:-1]+'$', tail, fh.read)
             fh.close()
-        except Exception, e:
+        except Exception as e:
             logging.critical(str(e))
             pass
 
@@ -466,7 +466,7 @@ class RemoteShell(cmd.Cmd):
             try:
                 self.__transferClient.getFile(self.__share, self.__output, output_callback)
                 break
-            except Exception, e:
+            except Exception as e:
                 if str(e).find('STATUS_SHARING_VIOLATION') >=0:
                     # Output not finished, let's wait
                     time.sleep(1)
@@ -650,7 +650,7 @@ def main():
         executer.run(address, options.method, options.bc_ip, options.contype, options.vncpass, options.vncport, options.invoke_vnc_path, options.httpport)
 
 
-    except (Exception, KeyboardInterrupt), e:
+    except (Exception, KeyboardInterrupt) as e:
         #import traceback
         #print traceback.print_exc()
         logging.error(str(e))


### PR DESCRIPTION
Python2 is end-of-life, this PR migrate Invoke-vnc to python3

This PR will help on the migration of CME to python3 

- https://github.com/byt3bl33d3r/CrackMapExec/issues/317
- https://github.com/byt3bl33d3r/CrackMapExec/pull/323